### PR TITLE
    Fix for issue #11

### DIFF
--- a/lunchbox/bitOperation.h
+++ b/lunchbox/bitOperation.h
@@ -33,8 +33,12 @@
 #  include <builtins.h>
 #  include <byteswap.h>
 #elif defined (LB_GCC_4_3_OR_OLDER) && !defined(__clang__)
-#  include <byteswap.h>
-#  define LB_GCC_BSWAP_FUNCTION
+#  if defined( __APPLE__ ) && !defined( AVAILABLE_MAC_OS_X_VERSION_10_7_AND_LATER ) && ( __GNUC__ == 4 ) && ( __GNUC_MINOR__ == 2 )
+#    undef LB_GCC_BSWAP_FUNCTION
+#  else
+#    include <byteswap.h>
+#    define LB_GCC_BSWAP_FUNCTION
+#  endif
 #endif
 
 namespace lunchbox


### PR DESCRIPTION
```
Fix for issue #11 - byteswap.h doesn't exist on Mac OS X 10.6.8 with gcc 4.2.1
```
