### PR TITLE
adding include unistd.h

### DIFF
--- a/lunchbox/launcher.cpp
+++ b/lunchbox/launcher.cpp
@@ -30,6 +30,7 @@
 #  include <io.h>
 #else
 #  include <sys/wait.h>
+#  include <unistd.h>
 #endif
 
 namespace lunchbox

--- a/lunchbox/log.cpp
+++ b/lunchbox/log.cpp
@@ -28,6 +28,8 @@
 #include <cstdlib>
 #ifdef WIN32_API
 #  include <process.h>
+#else
+#  include <unistd.h>
 #endif
 
 #ifdef _MSC_VER

--- a/lunchbox/memoryMap.cpp
+++ b/lunchbox/memoryMap.cpp
@@ -25,6 +25,7 @@
 #include <sys/stat.h>
 #ifndef _WIN32
 #   include <sys/mman.h>
+#   include <unistd.h>
 #endif
 
 namespace lunchbox


### PR DESCRIPTION
Include unistd.h is needed to compile Lunchbox 1.4 with gcc 4.7
