### PR TITLE
Adding value_type definition to container classes

### DIFF
--- a/lunchbox/lfVector.h
+++ b/lunchbox/lfVector.h
@@ -101,6 +101,9 @@ public:
     /** Iterator over the const vector elements. @version 1.3.2 */
     typedef LFVectorIterator<const LFVector<T, nSlots>, const T> const_iterator;
 
+    /** Value type. @version 1.3.x */
+    typedef T value_type;
+
     const_iterator begin() const; //!< @version 1.3.2
     const_iterator end() const; //!< @version 1.3.2
     iterator begin(); //!< @version 1.3.2

--- a/lunchbox/mtQueue.h
+++ b/lunchbox/mtQueue.h
@@ -213,6 +213,9 @@ namespace lunchbox
         bool empty() const { return isEmpty(); }
         //@}
 
+        /** Value type. @version 1.7.x */
+        typedef T value_type;
+
     private:
         std::deque< T > _queue;
         mutable Condition _cond;


### PR DESCRIPTION
Added "typedef T value_type;"  to the containers for the internal types to be used outside.
