### PR TITLE
Use https as protocol for CMake.

### DIFF
--- a/.gitexternals
+++ b/.gitexternals
@@ -1,2 +1,2 @@
 # -*- mode: cmake -*-
-# CMake/common git://github.com/Eyescale/CMake.git 7d5d210
+# CMake/common https://github.com/Eyescale/CMake.git 7d5d210


### PR DESCRIPTION
In some cases the git:// protocol might not work (connection refused). Using https instead.
