### PR TITLE
Fix bug in avahi local browsing

### DIFF
--- a/lunchbox/avahi/servus.h
+++ b/lunchbox/avahi/servus.h
@@ -331,7 +331,10 @@ private:
             const size_t pos = hostStr.find_last_of( "." );
             const std::string hostName = hostStr.substr( 0, pos );
 
-            if( hostName != getHostname( ))
+            const std::string& localHost = getHostname();
+            // omit the domain for the local hostname
+            if( hostName != localHost.substr( 0,
+                                              localHost.find_first_of( "." )))
                 return;
         }
 


### PR DESCRIPTION
This change is needed for discovering/browsing when the IF_LOCAL interface is specified, as apparently we can only get the host name (without the domain) from avahi.
