### PR TITLE
IOPlugin can have different parameters to the constructor

### DIFF
--- a/lunchbox/ioPluginFactory.h
+++ b/lunchbox/ioPluginFactory.h
@@ -44,15 +44,16 @@
 namespace lunchbox
 {
 
-template< typename IOPluginT > class IOPlugin;
+template< typename IOPluginT, typename InitDataT > class IOPlugin;
 
 /**
  * Abstract factory for IOPluginT classes with plugin registration
  * functionality.
  *
  * The IOPluginAbstractFactory selects the most appropriate plugin factory for a
- * given URI based on a plugin's handles( URI ) function. In case a URI can be
- * handled by multiple plugins, which plugin is chosen is undefined.
+ * given InitDataT ( default is URI ) based on a plugin's handles InitDataT
+ * function. In case a InitDataT can be handled by multiple plugins, which plugin is
+ * chosen is undefined.
  *
  * This class has been designed as a singleton to allow for link time plugin
  * registration, but nothing prevents an application from registering new types
@@ -65,27 +66,27 @@ template< typename IOPluginT > class IOPlugin;
  *
  * @version 1.10.0
  */
-template< typename IOPluginT >
+template< typename IOPluginT, typename InitDataT = URI >
 class IOPluginAbstractFactory : public boost::noncopyable
 {
 public:
-    typedef std::vector< IOPlugin< IOPluginT > > IOPlugins;
+    typedef std::vector< IOPlugin< IOPluginT, InitDataT > > IOPlugins;
 
     /** Get the single class instance. @version 1.10.0 */
     static IOPluginAbstractFactory& getInstance();
 
     /**
      * Create a plugin instance.
-     * @param uri The uri passed to the plugin constructor.
+     * @param initData The initData passed to the plugin constructor.
      * @return A new IOPluginT instance. The user is responsible for deleting
      *         the returned object.
-     * @throws std::runtime_error if no plugin can handle the uri.
-     * @version 1.10.0
+     * @throws std::runtime_error if no plugin can handle the initData.
+     * @version 1.11.0
      */
-    IOPluginT* create( const URI& uri );
+    IOPluginT* create( const InitDataT& initData );
 
-    /** Register a plugin type. @version 1.10.0 */
-    void registerPlugin( const IOPlugin< IOPluginT >& plugin );
+    /** Register a plugin type. @version 1.11.0 */
+    void registerPlugin( const IOPlugin< IOPluginT, InitDataT >& plugin );
 
     /** Unregister all plugin types. @version 1.10.0 */
     void unregisterAllPlugins();
@@ -102,55 +103,57 @@ private:
  * Plugin classes deriving from IOPluginT must implement the following
  * prototype for their constructor:
  * @code
- * DerivedPluginClass( const URI& uri );
+ * DerivedPluginClass( const InitDataT& initData );
  * @endcode
  *
  * They must also implement the following method to be registered:
  * @code
- * static bool handles( const URI& uri );
+ * static bool handles( const InitDataT& initData );
  * @endcode
  *
  * @version 1.10.0
  */
-template< typename IOPluginT >
+template< typename IOPluginT, typename InitDataT = URI >
 class IOPlugin
 {
 public:
     /**
      * The constructor method / concrete factory for IOPlugin objects.
-     * @version 1.10.0
+     * @version 1.11.0
      */
-    typedef boost::function< IOPluginT* ( const URI& ) > Constructor;
+    typedef boost::function< IOPluginT* ( const InitDataT& ) > Constructor;
 
     /**
-     * The method to check if the plugin can handle a given uri.
-     * @version 1.10.0
+     * The method to check if the plugin can handle a given initData.
+     * @version 1.11.0
      */
-    typedef boost::function< bool ( const URI& ) > HandlesFunc;
+    typedef boost::function< bool ( const InitDataT& ) > HandlesFunc;
 
     /**
      * Construct a new IOPlugin.
      * @param constructor_ The constructor method for IOPlugin objects.
-     * @param handles_ The method to check if the plugin can handle the uri.
+     * @param handles_ The method to check if the plugin can handle the
+     * initData.
      * @version 1.10.0
      */
     IOPlugin( const Constructor& constructor_, const HandlesFunc& handles_ );
 
 private:
-    friend class IOPluginAbstractFactory< IOPluginT >;
+    friend class IOPluginAbstractFactory< IOPluginT, InitDataT >;
 
     Constructor constructor;
     HandlesFunc handles;
 };
 
 /**
- * Helper class to statically register derived plugin classes.
+ * Helper class to statically register derived plugin classes. If MyInitDataType
+ * is not given, default value is lunchbox::URI.
  *
  * The following code can be placed in a plugin's cpp file:
  * @code
  * namespace
  * {
- *     IOPluginRegisterer< MyPluginClass > registerer;
+ *     IOPluginRegisterer< MyPluginInterface > registerer;
  * }
  * @endcode
  *
@@ -161,13 +164,49 @@ private:
  * {
  * public:
  *     typedef MyPluginInterface IOPluginT;
+       typedef MyPluginInitData InitDataT;
+                ( optional for InitDataT == lunchbox::URI )
  * }
  * @endcode
  *
  * @version 1.10.0
  */
-template< typename Impl >
+
+template< class T > struct hasInitDataT
+{
+    // SFINAE class to check whether class T has a typedef InitDataT
+    // If class has the typedef, "value" is known in compile time as true,
+    // else value is false.
+
+    // SFINAE is used for specializing the IOPluginRegisterer class
+    // when no InitDataT is defined.
+    template<class U> static char (&test(typename U::InitDataT const*))[1];
+    template<class U> static char (&test(...))[2];
+    static const bool value = (sizeof(test<T>(0)) == 1);
+};
+
+template< typename Impl, bool hasInitData = hasInitDataT< Impl >::value >
 class IOPluginRegisterer
+{
+public:
+    /** Construct a registerer and register the Impl class. @version 1.10.0 */
+    IOPluginRegisterer();
+};
+
+// Specialized IOPluginRegisterer class for plugin implementations which have
+// the InitDataT definition.
+template< typename Impl >
+class IOPluginRegisterer< Impl, true >
+{
+public:
+    /** Construct a registerer and register the Impl class. @version 1.10.0 */
+    IOPluginRegisterer();
+};
+
+// Specialized IOPluginRegisterer class for plugin implementations which don't
+// have the InitDataT definition.
+template< typename Impl >
+class IOPluginRegisterer< Impl, false >
 {
 public:
     /** Construct a registerer and register the Impl class. @version 1.10.0 */


### PR DESCRIPTION
Not to modify current plugins, IOPluginRegisterer class should get two parameters and one is defaulting to URI. But to me clear way is, defining the template parameter ParameterT in the plugin class is nicer and cleaner. I am ok with both.
