### PR TITLE
Fix for demangleTypeID.

### DIFF
--- a/lunchbox/debug.cpp
+++ b/lunchbox/debug.cpp
@@ -179,7 +179,7 @@ std::string demangleTypeID( const char* mangled )
 #else
     int status;
     char* name = abi::__cxa_demangle( mangled, 0, 0, &status );
-    if( !name || status == 0 )
+    if( !name || status != 0 )
     {
         free( name );
         return mangled;


### PR DESCRIPTION
abi::__cxa_demangle status == 0 means no error ocurred.

free( name ) can be kept because if an error occurs __cxa_demangle returns 0 and free(0) is correct.
