### PR TITLE
PersistentMap Improvements

### DIFF
--- a/.gitexternals
+++ b/.gitexternals
@@ -1,2 +1,2 @@
 # -*- mode: cmake -*-
-# CMake/common https://github.com/Eyescale/CMake.git bc88771
+# CMake/common https://github.com/Eyescale/CMake.git 38c69b3

--- a/CMake/GitExternal.cmake
+++ b/CMake/GitExternal.cmake
@@ -35,7 +35,7 @@ if(NOT GIT_EXECUTABLE)
 endif()
 
 include(CMakeParseArguments)
-option(GIT_EXTERNAL_DISABLE_UPDATE "Disable update of cloned repositories" ON)
+option(GIT_EXTERNAL_DISABLE_UPDATE "Disable update of cloned repositories" OFF)
 option(GIT_EXTERNAL_VERBOSE "Print git commands as they are executed" OFF)
 
 set(GIT_EXTERNAL_USER $ENV{GIT_EXTERNAL_USER})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,15 @@ set(COMMON_PROJECT_DOMAIN ch.eyescale)
 
 include(Common)
 
+if(BLUEGENE)
+  option(LUNCHBOX_USE_SKV "Enable SKV functionality if found" ON)
+else()
+  option(LUNCHBOX_USE_SKV "Enable SKV functionality if found" OFF)
+endif()
+if(LUNCHBOX_USE_SKV)
+  git_subproject(skv https://github.com/eile/skv.git 2e7e137)
+endif()
+
 list(APPEND CPPCHECK_EXTRA_ARGS -DLB_GCC_4_1_OR_LATER=1)
 if(LUNCHBOX_BUILD_V2_API)
   list(APPEND FIND_PACKAGES_DEFINES LUNCHBOX_USE_V2_API)

--- a/lunchbox/persistentMap.cpp
+++ b/lunchbox/persistentMap.cpp
@@ -1,5 +1,5 @@
 
-/* Copyright (c) 2014, Stefan.Eilemann@epfl.ch
+/* Copyright (c) 2014-2015, Stefan.Eilemann@epfl.ch
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License version 2.1 as published
@@ -25,12 +25,18 @@ namespace detail
 class PersistentMap
 {
 public:
+    PersistentMap() : swap( false ) {}
     virtual ~PersistentMap() {}
+    virtual size_t setQueueDepth( const size_t ) { return 0; }
     virtual bool insert( const std::string& key, const void* data,
                          const size_t size ) = 0;
     virtual std::string operator [] ( const std::string& key ) const = 0;
+    virtual bool fetch( const std::string&, const size_t ) const
+        { return true; }
     virtual bool contains( const std::string& key ) const = 0;
     virtual bool flush() = 0;
+
+    bool swap;
 };
 }
 }
@@ -102,6 +108,11 @@ bool PersistentMap::handles( const URI& uri )
     return false;
 }
 
+size_t PersistentMap::setQueueDepth( const size_t depth )
+{
+    return _impl->setQueueDepth( depth );
+}
+
 bool PersistentMap::_insert( const std::string& key, const void* data,
                              const size_t size )
 {
@@ -113,6 +124,11 @@ std::string PersistentMap::operator [] ( const std::string& key ) const
     return (*_impl)[ key ];
 }
 
+bool PersistentMap::fetch( const std::string& key, const size_t sizeHint ) const
+{
+    return _impl->fetch( key, sizeHint );
+}
+
 bool PersistentMap::contains( const std::string& key ) const
 {
     return _impl->contains( key );
@@ -121,6 +137,16 @@ bool PersistentMap::contains( const std::string& key ) const
 bool PersistentMap::flush()
 {
     return _impl->flush();
+}
+
+void PersistentMap::setByteswap( const bool swap )
+{
+    _impl->swap = swap;
+}
+
+bool PersistentMap::_swap() const
+{
+    return _impl->swap;
 }
 
 }

--- a/lunchbox/persistentMap.h
+++ b/lunchbox/persistentMap.h
@@ -1,5 +1,5 @@
 
-/* Copyright (c) 2014, Stefan.Eilemann@epfl.ch
+/* Copyright (c) 2014-2015, Stefan.Eilemann@epfl.ch
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License version 2.1 as published
@@ -19,10 +19,13 @@
 #define LUNCHBOX_PERSISTENTMAP_H
 
 #include <lunchbox/api.h>
+#include <lunchbox/bitOperation.h> // byteswap()
 #include <lunchbox/debug.h> // className
 #include <lunchbox/log.h> // LBTHROW
 #include <lunchbox/types.h>
 
+#include <boost/foreach.hpp>
+#include <boost/lexical_cast.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/type_traits.hpp>
 
@@ -75,6 +78,20 @@ public:
     LUNCHBOX_API static bool handles( const URI& uri );
 
     /**
+     * Set the maximum number of asynchronous outstanding write operations.
+     *
+     * Some backend implementations support asynchronous writes, which can be
+     * enabled by setting a non-zero queue depth. Applications then need to
+     * quarantee that the inserted values stay valid until 'depth' other
+     * elements have been inserted or flush() has been called. Implementations
+     * which do not support asynchronous writes return 0.
+     *
+     * @return the queue depth chosen by the implementation, smaller or equal to
+     *         the given depth.
+     */
+    size_t setQueueDepth( const size_t depth );
+
+    /**
      * Insert or update a value in the database.
      *
      * @param key the key to store the value.
@@ -115,29 +132,52 @@ public:
     /**
      * Retrieve a value for a key.
      *
-     * @param key the key to retreive.
+     * @param key the key to retrieve.
      * @return the value, or an empty string if the key is not available.
      * @version 1.9.2
      */
     LUNCHBOX_API std::string operator [] ( const std::string& key ) const;
 
     /**
+     * Retrieve a value for a key.
+     *
+     * @param key the key to retrieve.
+     * @return the value, or an empty string if the key is not available.
+     * @version 1.9.2
+     */
+    template< class V > V get( const std::string& key ) const
+        { return _get< V >( key ); }
+
+    /**
      * Retrieve a value as a vector for a key.
      *
-     * @param key the key to retreive.
+     * @param key the key to retrieve.
      * @return the values, or an empty vector if the key is not available.
      * @version 1.9.2
      */
-    template< class V > std::vector< V > getVector( const std::string& key );
+    template< class V > std::vector< V > getVector( const std::string& key )
+        const;
 
     /**
      * Retrieve a value as a set for a key.
      *
-     * @param key the key to retreive.
+     * @param key the key to retrieve.
      * @return the values, or an empty set if the key is not available.
      * @version 1.9.2
      */
-    template< class V > std::set< V > getSet( const std::string& key );
+    template< class V > std::set< V > getSet( const std::string& key ) const;
+
+    /**
+     * Asynchronously retrieve a value which to be read later.
+     *
+     * Might be implemented as a 'NOP' by backend implementations.
+     *
+     * @param key the key to retrieve.
+     * @param sizeHint the size of the value, may be ignored by implementation.
+     * @return false on error, true otherwise.
+     * @version 1.9.2
+     */
+    bool fetch( const std::string& key, size_t sizeHint = 0 ) const;
 
     /** @return true if the key exists. @version 1.9.2 */
     LUNCHBOX_API bool contains( const std::string& key ) const;
@@ -145,11 +185,15 @@ public:
     /** Flush outstanding operations to the backend storage. @version 1.10 */
     LUNCHBOX_API bool flush();
 
+    /** Enable or disable endianness conversion on reads. @version 1.9.2 */
+    LUNCHBOX_API void setByteswap( const bool swap );
+
 private:
     detail::PersistentMap* const _impl;
 
     LUNCHBOX_API bool _insert( const std::string& key, const void* data,
                                const size_t size );
+    LUNCHBOX_API bool _swap() const;
 
 
     // Enables map.insert( "foo", "bar" ); bar is a char[4]. The funny braces
@@ -177,6 +221,26 @@ private:
     bool _insert( const std::string& key, const std::vector< V >& values,
                   const boost::true_type& )
         { return _insert( key, values.data(), values.size() * sizeof( V )); }
+
+    template< class V > V _get( const std::string& k ) const
+    {
+        if( !boost::has_trivial_assign< V >( ))
+            LBTHROW( std::runtime_error( "Can't retrieve non-POD " +
+                                         className( V( ))));
+        if( boost::is_pointer< V >::value )
+            LBTHROW( std::runtime_error( "Can't retrieve pointers" ));
+
+        const std::string& value = (*this)[ k ];
+        if( value.size() != sizeof( V ))
+            LBTHROW( std::runtime_error( std::string( "Wrong value size " ) +
+                            boost::lexical_cast< std::string >( value.size( )) +
+                                         " for type " + className( V( ))));
+
+        V v( *reinterpret_cast< const V* >( value.data( )));
+        if( _swap( ))
+            byteswap( v );
+        return v;
+    }
 };
 
 template<> inline
@@ -187,24 +251,34 @@ bool PersistentMap::_insert( const std::string& k, const std::string& v,
 }
 
 template< class V > inline
-std::vector< V > PersistentMap::getVector( const std::string& key )
+std::vector< V > PersistentMap::getVector( const std::string& key ) const
 {
     const std::string& value = (*this)[ key ];
-    return std::vector< V >( reinterpret_cast< const V* >( value.data( )),
+    std::vector< V > vector( reinterpret_cast< const V* >( value.data( )),
                    reinterpret_cast< const V* >( value.data() + value.size( )));
+    if( _swap() && sizeof( V ) != 1 )
+    {
+        BOOST_FOREACH( V& elem, vector )
+            byteswap( elem );
+    }
+    return vector;
 }
 
 template< class V > inline
-std::set< V > PersistentMap::getSet( const std::string& key )
+std::set< V > PersistentMap::getSet( const std::string& key ) const
 {
-    const std::string& value = (*this)[ key ];
-    return std::set< V >( reinterpret_cast< const V* >( value.data( )),
-                          reinterpret_cast< const V* >( value.data() +
-                                                        value.size( )));
+    std::string value = (*this)[ key ];
+    V* const begin = reinterpret_cast< V* >(
+                         const_cast< char * >( value.data( )));
+    V* const end = begin + value.size() / sizeof( V );
+
+    if( _swap() && sizeof( V ) != 1 )
+        for( V* i = begin; i < end; ++i )
+            byteswap( *i );
+
+    return std::set< V >( begin, end );
 }
 
-
-// inline std::ostream& operator << ( std::ostream& os, const PersistentMap& m )
 }
 
 #endif //LUNCHBOX_PERSISTENTMAP_H

--- a/lunchbox/skv/persistentMap.h
+++ b/lunchbox/skv/persistentMap.h
@@ -17,22 +17,25 @@
 
 #ifdef LUNCHBOX_USE_SKV
 
+#include <lunchbox/array.h>
 #include <lunchbox/compiler.h>
 #include <lunchbox/futureFunction.h>
 #include <lunchbox/log.h>
-#include <boost/bind.hpp>
+#include <lunchbox/stdExt.h>
 
 #define SKV_CLIENT_UNI
 #define SKV_NON_MPI
 #include <skv/client/skv_client.hpp>
+
+#include <algorithm>
 
 // Note: skv api is not const-correct. Ignore all const_cast and mutable below.
 namespace lunchbox
 {
 namespace
 {
-typedef std::deque< skv_client_cmd_ext_hdl_t > PendingOperations;
-static const size_t _maxPendingOps = 100000;
+typedef std::deque< skv_client_cmd_ext_hdl_t > PendingPuts;
+static const int bufferSize = 65536;
 }
 
 namespace skv
@@ -41,6 +44,7 @@ class PersistentMap : public detail::PersistentMap
 {
 public:
     PersistentMap( const URI& uri )
+        : _maxPendingOps( 0 )
     {
 #ifdef SKV_CLIENT_UNI
         skv_status_t status = _client.Init( 0, 0 );
@@ -66,23 +70,40 @@ public:
 
     virtual ~PersistentMap()
     {
-        flush();
+        LBCHECK( flush( ));
         _client.Close( &_namespace );
         _client.Disconnect();
         _client.Finalize();
+
+        LBASSERTINFO( _reads.empty(), _reads.size() << " pending reads" );
+        LBASSERT( _writes.empty( ));
     }
 
     static bool handles( const URI& uri ) { return uri.getScheme() == "skv"; }
 
+    size_t setQueueDepth( const size_t depth ) final
+    {
+        // SKV impl has max 128k queue depth
+        _maxPendingOps = std::min( depth, size_t( LB_128KB ));
+        LBCHECK( _flush( _maxPendingOps ));
+        return _maxPendingOps;
+    }
+
     bool insert( const std::string& key, const void* data, const size_t size )
         final
     {
-        skv_client_cmd_ext_hdl_t handle;
-        const skv_status_t status =
+        skv_client_cmd_ext_hdl_t handle = 0;
+        const bool useAsync = ( _maxPendingOps > 0 );
+        const skv_status_t status = useAsync ?
             _client.iInsert( &_namespace,
+                             const_cast< char* >( key.c_str( )), key.length(),
+                             static_cast< char* >( const_cast< void* >( data )),
+                             size, 0, SKV_COMMAND_RIU_UPDATE, &handle ) :
+            _client.Insert( &_namespace,
                             const_cast< char* >( key.c_str( )), key.length(),
                             static_cast< char* >( const_cast< void* >( data )),
-                             size, 0, SKV_COMMAND_RIU_UPDATE, &handle );
+                            size, 0, SKV_COMMAND_RIU_UPDATE );
+
         if( status != SKV_SUCCESS )
         {
             LBINFO << "skv insert failed: " << skv_status_to_string( status )
@@ -90,7 +111,8 @@ public:
             return false;
         }
 
-        _pending.push_back( handle );
+        if( useAsync )
+            _writes.push_back( handle );
         return _flush( _maxPendingOps );
     }
 
@@ -101,6 +123,31 @@ public:
         if( status != SKV_SUCCESS )
             value.clear();
         return value;
+    }
+
+    bool fetch( const std::string& key, const size_t sizeHint ) const final
+    {
+        if( (_writes.size() + _reads.size( )) >= LB_128KB )
+            return true; // hard SKV limit on pending reqs
+
+        AsyncRead& asyncRead = _reads[ key ];
+        if( !asyncRead.value.empty( ))
+            return true; // fetch for key already pending
+
+        asyncRead.value.resize( sizeHint > 0 ? sizeHint : bufferSize );
+        const skv_status_t status =
+            _client.iRetrieve( &_namespace,
+                               const_cast< char* >( key.c_str( )), key.length(),
+                               const_cast< char* >( asyncRead.value.c_str( )),
+                               asyncRead.value.length(), &asyncRead.size, 0,
+                               SKV_COMMAND_RIU_FLAGS_NONE, &asyncRead.handle );
+
+        if( status == SKV_SUCCESS )
+            return true;
+
+        LBWARN << "skv fetch failed: " << skv_status_to_string( status )
+               << std::endl;
+        return false;
     }
 
     bool contains( const std::string& key ) const final
@@ -114,37 +161,114 @@ public:
 private:
     mutable skv_client_t _client;
     mutable skv_pds_id_t _namespace;
-    PendingOperations _pending;
+    PendingPuts _writes;
+
+    struct AsyncRead
+    {
+        AsyncRead() : handle( 0 ), size( 0 ) {}
+
+        skv_client_cmd_ext_hdl_t  handle;
+        std::string               value;
+        int                       size;
+    };
+
+    typedef stde::hash_map< std::string, AsyncRead > ReadMap;
+    typedef ReadMap::iterator ReadMapIter;
+
+    mutable ReadMap _reads;
+    size_t _maxPendingOps;
 
     skv_status_t _retrieve( const std::string& key, std::string& value ) const
     {
-        static const size_t bufferSize = 65536;
-        char buffer[ bufferSize ];
-        int valueSize = 0;
+        ReadMapIter i = _reads.find( key );
+        if( i == _reads.end( )) // no async fetch pending
+        {
+            char buffer[ bufferSize ];
+            int valueSize = 0;
+            skv_status_t status =
+                _client.Retrieve( &_namespace,
+                                  const_cast< char* >( key.c_str( )),
+                                  key.length(),
+                                  buffer, bufferSize, &valueSize, 0,
+                                  SKV_COMMAND_RIU_FLAGS_NONE );
+            if( status != SKV_SUCCESS )
+                return status;
 
-        const skv_status_t status =
-            _client.Retrieve( &_namespace,
-                              const_cast< char* >( key.c_str( )), key.length(),
-                              buffer, bufferSize, &valueSize, 0,
-                              SKV_COMMAND_RIU_FLAGS_NONE );
-        value.assign( buffer, valueSize );
+            if( valueSize > bufferSize ) // not enough read, read remainder
+            {
+                value.assign( buffer, bufferSize );
+                value.resize( valueSize );
+                valueSize -= bufferSize;
+                status = _client.Retrieve( &_namespace,
+                                           const_cast< char* >( key.c_str( )),
+                                           key.length(),
+                                           const_cast< char* >( value.data() +
+                                                                bufferSize ),
+                                           valueSize, &valueSize, bufferSize,
+                                           SKV_COMMAND_RIU_FLAGS_NONE );
+                if( status != SKV_SUCCESS )
+                    return status;
+            }
+            else
+                value.assign( buffer, valueSize );
+            return SKV_SUCCESS;
+        }
+
+        // asking for a key with pending gets, check async receives
+        AsyncRead& asyncRead = i->second;
+        skv_status_t status = _client.Wait( asyncRead.handle );
+        if( status == SKV_SUCCESS )
+        {
+            if( asyncRead.value.size() < size_t( asyncRead.size ))
+            {   // not enough read, read remainder
+                value.swap( asyncRead.value );
+                const int rest = asyncRead.size - value.size();
+                const int offset = value.size();
+                value.resize( asyncRead.size );
+
+                status = _client.Retrieve( &_namespace,
+                                           const_cast< char* >( key.c_str( )),
+                                           key.length(),
+                                           const_cast< char* >( value.data() +
+                                                                offset ),
+                                           rest, &asyncRead.size,
+                                           offset, SKV_COMMAND_RIU_FLAGS_NONE );
+            }
+            else
+            {
+                asyncRead.value.resize( asyncRead.size );
+                value.swap( asyncRead.value );
+            }
+        }
+        _reads.erase( i );
         return status;
     }
 
     bool _flush( const size_t maxPending )
     {
-        while( _pending.size() > maxPending )
+        bool ok = true;
+        while( _writes.size() > maxPending )
         {
-            skv_client_cmd_ext_hdl_t handle = _pending.front();
-            _pending.pop_front();
-            if( _client.Wait( handle ) != SKV_SUCCESS )
-                return false;
+            const skv_client_cmd_ext_hdl_t handle = _writes.front();
+            _writes.pop_front();
+            const skv_status_t status = _client.Wait( handle );
+            if( status != SKV_SUCCESS )
+            {
+                if( ok )
+                    LBWARN << "skv flush failed: "
+                           << skv_status_to_string( status ) << " for "
+                           << handle << std::endl;
+                else
+                    LBINFO << "skv flush failed: "
+                           << skv_status_to_string( status ) << " for "
+                           << handle << std::endl;
+                ok = false;
+            }
         }
-        return true;
+        return ok;
     }
 };
 
 }
 }
-
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ set(TEST_LIBRARIES Lunchbox ${Boost_LIBRARIES})
 if(COVERAGE AND TRAVIS)
   list(APPEND EXCLUDE_FROM_TESTS anySerialization.cpp) #timeout in lcov gather
 endif()
+set(UNIT_AND_PERF_TESTS persistentMap.cpp)
 
 include(CommonCTest)
 install_files(share/Lunchbox/tests FILES ${TEST_FILES} COMPONENT examples)

--- a/tests/persistentMap.cpp
+++ b/tests/persistentMap.cpp
@@ -15,7 +15,10 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#define TEST_RUNTIME 240 //seconds
 #include <test.h>
+#include <lunchbox/clock.h>
+#include <lunchbox/os.h>
 #include <lunchbox/persistentMap.h>
 #ifdef LUNCHBOX_USE_LEVELDB
 #  include <leveldb/db.h>
@@ -23,29 +26,76 @@
 #ifdef LUNCHBOX_USE_SKV
 #  include <FxLogger/FxLogger.hpp>
 #endif
+#include <boost/format.hpp>
 #include <stdexcept>
 
 using lunchbox::PersistentMap;
 
 const int ints[] = { 17, 53, 42, 65535, 32768 };
 const size_t numInts = sizeof( ints ) / sizeof( int );
+const int64_t loopTime = 1000;
 
 template< class T > void insertVector( PersistentMap& map )
 {
     std::vector< T > vector;
     for( size_t i = 0; i < numInts; ++i )
         vector.push_back( T( ints[ i ] ));
-
     TEST( map.insert( typeid( vector ).name(), vector ));
 }
 
-template< class T > void readVector( PersistentMap& map )
+template< class T > void readVector( const PersistentMap& map )
 {
     const std::vector< T >& vector =
         map.getVector< T >( typeid( vector ).name( ));
     TESTINFO( vector.size() ==  numInts, vector.size() << " != " << numInts );
     for( size_t i = 0; i < numInts; ++i )
         TEST( vector[ i ] == T( ints[i] ));
+}
+
+template< class T > void insertVector( PersistentMap& map, const size_t elems )
+{
+    std::vector< T > vector;
+    for( size_t i = 0; i < elems; ++i )
+        vector.push_back( i );
+    TEST( map.insert( std::string( "bulk" ) + typeid( vector ).name(), vector ));
+}
+
+template< class T > void readVector( const PersistentMap& map, const size_t elems )
+{
+    const std::vector< T >& vector =
+        map.getVector< T >( std::string( "bulk" ) + typeid( vector ).name());
+    TESTINFO( vector.size() ==  elems, vector.size() << " != " << elems );
+    for( size_t i = 0; i < numInts; ++i )
+        TESTINFO( vector[ i ] == T( i ), vector[ i ] << " != " << i );
+}
+
+void read( const PersistentMap& map )
+{
+    const std::set< uint32_t >& bigSet =
+        map.getSet< uint32_t >( "std::set< uint32_t >" );
+    TEST( bigSet.size() == 1000 );
+    for( uint32_t i = 1; i <= 1000; ++i )
+        TEST( bigSet.find( i ) != bigSet.end( ));
+
+    TEST( map[ "foo" ] == "bar" );
+    TEST( map[ "bar" ].empty( ));
+    TEST( map.get< bool >( "bValue" ) == true );
+    TEST( map.get< int >( "iValue" ) == 42 );
+
+    readVector< int >( map );
+    readVector< uint16_t >( map );
+
+    const std::set< int >& set = map.getSet< int >( "std::set< int >" );
+    TESTINFO( set.size() ==  numInts, set.size() << " != " << numInts );
+    for( size_t i = 0; i < numInts; ++i )
+        TESTINFO( set.find( ints[i] ) != set.end(),
+                  ints[i] << " not found in set" );
+}
+
+void read( const std::string& uri )
+{
+    PersistentMap map( uri );
+    read( map );
 }
 
 void setup( const std::string& uri )
@@ -64,29 +114,134 @@ void setup( const std::string& uri )
     TEST( map.insert( "hans", std::string( "dampf" )));
     TESTINFO( map[ "hans" ] == "dampf", map[ "hans" ] );
 
+    const bool bValue = true;
+    TEST( map.insert( "bValue", bValue ));
+    TEST( map.get< bool >( "bValue" ) == bValue );
+
+    const int iValue = 42;
+    TEST( map.insert( "iValue", iValue ));
+    TEST( map.get< int >( "iValue" ) == iValue );
+
+    TEST( map.insert( "coffee", 0xC0FFEE ));
+    map.setByteswap( true );
+    TEST( map.get< unsigned >( "coffee" ) == 0xEEFFC000u );
+    map.setByteswap( false );
+    TEST( map.get< int >( "coffee" ) == 0xC0FFEE );
+
     insertVector< int >( map );
     insertVector< uint16_t >( map );
     readVector< int >( map );
     readVector< uint16_t >( map );
 
+    insertVector< int >( map, LB_128KB );
+    insertVector< uint16_t >( map, LB_128KB );
+    map.fetch( std::string( "bulk" ) + typeid( std::vector< int > ).name( ));
+    map.fetch( std::string( "bulk" ) + typeid( std::vector<uint16_t> ).name( ));
+    readVector< int >( map, LB_128KB );
+    readVector< uint16_t >( map, LB_128KB );
+
     std::set< int > set( ints, ints + numInts );
     TEST( map.insert( "std::set< int >", set ));
+
+    std::set< uint32_t > bigSet;
+    for( uint32_t i = 1; i <= 1000; ++i )
+        bigSet.insert( i );
+    TEST( map.insert( "std::set< uint32_t >", bigSet ));
+
+    read( map );
 }
 
-void read( const std::string& uri )
+void benchmark( const std::string& uri, const uint64_t queueDepth )
 {
     PersistentMap map( uri );
-    TEST( map[ "foo" ] == "bar" );
-    TEST( map[ "bar" ].empty( ));
+    map.setQueueDepth( queueDepth );
 
-    readVector< int >( map );
-    readVector< uint16_t >( map );
+    // Prepare keys
+    lunchbox::Strings keys;
+    keys.resize( queueDepth + 1 );
+    for( uint64_t i = 0; i <= queueDepth; ++i )
+        keys[i].assign( reinterpret_cast< char* >( &i ), 8 );
 
-    const std::set< int >& set = map.getSet< int >( "std::set< int >" );
-    TESTINFO( set.size() ==  numInts, set.size() << " != " << numInts );
-    for( size_t i = 0; i < numInts; ++i )
-        TESTINFO( set.find( ints[i] ) != set.end(),
-                  ints[i] << " not found in set" );
+    // write performance
+    lunchbox::Clock clock;
+    uint64_t i = 0;
+    while( clock.getTime64() < loopTime )
+    {
+        std::string& key = keys[ i % (queueDepth+1) ];
+        *reinterpret_cast< uint64_t* >( &key[0] ) = i;
+        map.insert( key, key );
+        ++i;
+    }
+    map.flush();
+    const float insertTime = clock.getTimef();
+    const uint64_t wOps = i;
+    TEST( i > queueDepth );
+
+    // read performance
+    std::string key;
+    key.assign( reinterpret_cast< char* >( &i ), 8 );
+
+    clock.reset();
+    if( queueDepth == 0 ) // sync read
+    {
+        for( i = 0; i < wOps && clock.getTime64() < loopTime; ++i ) // read keys
+        {
+            *reinterpret_cast< uint64_t* >( &key[0] ) = i - queueDepth;
+            map[ key ];
+        }
+    }
+    else // fetch + async read
+    {
+        for( i = 0; i < queueDepth; ++i ) // prefetch queueDepth keys
+        {
+            *reinterpret_cast< uint64_t* >( &key[0] ) = i;
+            TEST( map.fetch( key, 8 ) );
+        }
+
+        for( ; i < wOps && clock.getTime64() < loopTime; ++i ) // read keys
+        {
+            *reinterpret_cast< uint64_t* >( &key[0] ) = i - queueDepth;
+            map[ key ];
+
+            *reinterpret_cast< uint64_t* >( &key[0] ) = i;
+            TEST( map.fetch( key, 8 ));
+        }
+
+        for( uint64_t j = i - queueDepth; j <= i; ++j ) // drain fetched keys
+        {
+            *reinterpret_cast< uint64_t* >( &key[0] ) = j;
+            map[ key ];
+        }
+    }
+
+    const float readTime = clock.getTimef();
+    const size_t rOps = i;
+
+    // fetch performance
+    clock.reset();
+    for( i = 0; i < wOps && clock.getTime64() < loopTime && i < LB_128KB; ++i )
+    {
+        *reinterpret_cast< uint64_t* >( &key[0] ) = i;
+        TEST( map.fetch( key, 8 ) );
+    }
+    const float fetchTime = clock.getTimef();
+    const size_t fOps = i;
+
+    std::cout << boost::format( "%7.2f, %7.2f, %7.2f, %6i")
+        // cppcheck-suppress zerodivcond
+        % queueDepth % (rOps/insertTime) % (wOps/readTime) % (fOps/fetchTime)
+              << std::endl;
+
+    // check contents of store (not all to save time on bigger tests)
+    for( uint64_t j = 0; j < wOps && clock.getTime64() < loopTime; ++j )
+    {
+        *reinterpret_cast< uint64_t* >( &key[0] ) = j;
+        TESTINFO( map.get< uint64_t >( key ) == j,
+                  j << " = " << map.get< uint64_t >( key ));
+    }
+
+    // try to make sure there's nothing outstanding if we messed up i our test.
+    map.flush();
 }
 
 void testGenericFailures()
@@ -117,8 +272,13 @@ void testLevelDBFailures()
 #endif
 }
 
-int main( int, char** argv LB_UNUSED )
+int main( int, char* argv[] )
 {
+    const bool perfTest LB_UNUSED
+        = std::string( argv[0] ).find( "perf_" ) != std::string::npos;
+    if( perfTest )
+        std::cout << "  async,    read,   write,   fetch" << std::endl;
+
     try
     {
 #ifdef LUNCHBOX_USE_LEVELDB
@@ -128,11 +288,19 @@ int main( int, char** argv LB_UNUSED )
         read( "" );
         read( "leveldb://" );
         read( "leveldb://persistentMap2.leveldb" );
+        if( perfTest )
+            benchmark( "leveldb://", 0 );
 #endif
 #ifdef LUNCHBOX_USE_SKV
-        FxLogger_Init( argv[ 0 ] );
+        FxLogger_Init( argv[0] );
         setup( "skv://" );
         read( "skv://" );
+        if( perfTest )
+        {
+            benchmark( "skv://", 0 );
+            for( size_t i=1; i < 100000; i = i<<1 )
+                benchmark( "skv://", i );
+        }
 #endif
     }
 #ifdef LUNCHBOX_USE_LEVELDB


### PR DESCRIPTION
* API for async writes: setQueueDepth()
* API for buffered reads: fetch()
* Support for builtin byteswapping
* templated get() for PODs
* Fix reading values >64k
* Performance and unit test