### PR TITLE
Defines SUPPORT_FOR_CPP11 macro when compiler supports C++11

### DIFF
--- a/lunchbox/compiler.h
+++ b/lunchbox/compiler.h
@@ -33,6 +33,9 @@
 #      define override
 #    endif
 #  endif
+#  if __cplusplus > 199711L
+#    define SUPPORT_FOR_CPP11
+#  endif
 #endif
 
 // align macros


### PR DESCRIPTION
SUPPORT_FOR_CPP11 is defined when the compiler supports C++11