### PR TITLE
Do not unregister requests when waitRequest times out.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ include(GitExternal)
 set(VERSION_MAJOR "1")
 set(VERSION_MINOR "12")
 set(VERSION_PATCH "0")
-set(VERSION_ABI 4)
+set(VERSION_ABI 5)
 option(LUNCHBOX_BUILD_V2_API
   "Enable for pure 2.0 API (breaks compatibility with 1.x API)" OFF)
 option(LUNCHBOX_USE_MPI "Enable MPI functionality if found" ON)

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -12,6 +12,10 @@
   getLibraryPaths: Fixes library path results for OSX and linux
 * [213](https://github.com/Eyescale/Lunchbox/pull/213):
   getExecutablePath: More sensible behaviour for OS X app bundles
+* [233]((https://github.com/Eyescale/Lunchbox/pull/233):
+  Fix RequestHandler::waitRequest to not unregister the request if it
+  times out.
+  Request::relinquished replaced by Request::unregister.
 
 # Release 1.11 (07-07-2015) {#Release111}
 

--- a/lunchbox/requestHandler.cpp
+++ b/lunchbox/requestHandler.cpp
@@ -98,9 +98,11 @@ public:
 
         const bool requestServed = request->lock.set( timeout );
         if( requestServed )
+        {
             result = request->result;
+            unregisterRequest( requestID_ );
+        }
 
-        unregisterRequest( requestID_ );
         return requestServed;
     }
 

--- a/lunchbox/requestHandler.h
+++ b/lunchbox/requestHandler.h
@@ -53,8 +53,7 @@ public:
     /**
      * Register a request.
      *
-     * @param data a pointer to user-specific data for the request, can be
-     *             0.
+     * @param data a pointer to user-specific data for the request, can be 0.
      * @return A Future which will be fulfilled on serveRequest().
      * @version 1.9.1
      */
@@ -63,14 +62,12 @@ public:
     /**
      * Register a request.
      *
-     * @param data a pointer to user-specific data for the request, can be
-     *             0.
+     * @param data a pointer to user-specific data for the request, can be 0.
      * @return the request identifier.
      * @version 1.0
      * @deprecated use the future-based registerRequest()
      */
-    uint32_t registerRequest( void* data = 0 ) LB_DEPRECATED
-        { return _register( data ); }
+    uint32_t registerRequest( void* data = 0 ) { return _register( data ); }
 
     /**
      * Unregister a request.


### PR DESCRIPTION
I have a loop that does something like this:

    lunchbox::Request<bool> request = ... // some call that returns a Request<bool>
    bool success;
    while (true)
    {
        try
        {
            success = request.wait(500);
            break;
        }
        catch (const lunchbox::FutureTimeout&)
        {
            ... // Do something that will allow the request to be granted.
        }
    }

It's been a surprise to find out that after the first timeout, the request is unregistered and any subsequent call to request.wait fails immediately.

Reading at requestHandler.cpp:100 I've found this:

        const bool requestServed = request->lock.set( timeout );
        if( requestServed )
            result = request->result;

        unregisterRequest( requestID_ );

This basically means that a timeout can only occur once and there's no way to retry. Changing the code to this:

       const bool requestServed = request->lock.set( timeout );
        if( requestServed )
        {
            result = request->result;
            unregisterRequest( requestID_ );
        }

works for me, but I wonder whether this can have an undesired side-effect on Equalizer.
