### PR TITLE
Dump all thread backtraces on abort

### DIFF
--- a/.gitexternals
+++ b/.gitexternals
@@ -1,2 +1,2 @@
 # -*- mode: cmake -*-
-# CMake/common https://github.com/Eyescale/CMake.git b158c68
+# CMake/common https://github.com/Eyescale/CMake.git ff9feb0

--- a/CMake/GitExternal.cmake
+++ b/CMake/GitExternal.cmake
@@ -34,12 +34,16 @@
 #    This is a global option which has the same effect as the VERBOSE option,
 #    with the difference that output information will be produced for all
 #    external repos when set.
+#  GIT_EXTERNAL_TAG
+#    If set, git external tags referring to a SHA1 (not a branch) will be
+#    overwritten by this value.
 #
 # CMake or environment variables:
 #  GITHUB_USER
 #    If set, a remote called 'user' is set up for github repositories, pointing
 #    to git@github.com:<user>/<project>. Also, this remote is used by default
 #    for 'git push'.
+
 
 if(NOT GIT_FOUND)
   find_package(Git QUIET)
@@ -69,8 +73,12 @@ function(JOIN VALUES GLUE OUTPUT)
   set (${OUTPUT} "${_TMP_STR}" PARENT_SCOPE)
 endfunction()
 
-function(GIT_EXTERNAL DIR REPO TAG)
+function(GIT_EXTERNAL DIR REPO tag)
   cmake_parse_arguments(GIT_EXTERNAL_LOCAL "VERBOSE;SHALLOW" "" "RESET" ${ARGN})
+  set(TAG ${tag})
+  if(GIT_EXTERNAL_TAG AND "${tag}" MATCHES "^[0-9a-f]+$")
+    set(TAG ${GIT_EXTERNAL_TAG})
+  endif()
 
   # check if we had a previous external of the same name
   string(REGEX REPLACE "[:/]" "_" TARGET "${DIR}")
@@ -143,7 +151,11 @@ function(GIT_EXTERNAL DIR REPO TAG)
       OUTPUT_QUIET ERROR_QUIET WORKING_DIRECTORY "${DIR}")
   endif()
 
-  file(RELATIVE_PATH __dir ${CMAKE_SOURCE_DIR} ${DIR})
+  if(COMMON_SOURCE_DIR)
+    file(RELATIVE_PATH __dir ${COMMON_SOURCE_DIR} ${DIR})
+  else()
+    file(RELATIVE_PATH __dir ${CMAKE_SOURCE_DIR} ${DIR})
+  endif()
   string(REGEX REPLACE "[:/\\.]" "-" __target "${__dir}")
   if(TARGET ${__target}-rebase)
     return()
@@ -154,7 +166,7 @@ function(GIT_EXTERNAL DIR REPO TAG)
     "if(NOT IS_DIRECTORY \"${DIR}/.git\")\n"
     "  message(FATAL_ERROR \"Can't update git external ${__dir}: Not a git repository\")\n"
     "endif()\n"
-    # check if we are already on the requested tag
+    # check if we are already on the requested tag (nothing to do)
     "execute_process(COMMAND \"${GIT_EXECUTABLE}\" rev-parse --short HEAD\n"
     "  OUTPUT_VARIABLE currentref OUTPUT_STRIP_TRAILING_WHITESPACE\n"
     "  WORKING_DIRECTORY \"${DIR}\")\n"
@@ -174,7 +186,7 @@ function(GIT_EXTERNAL DIR REPO TAG)
     "    WORKING_DIRECTORY \"${DIR}\")\n"
     "endforeach()\n"
     "\n"
-    # fetch latest update
+    # fetch updates
     "execute_process(COMMAND \"${GIT_EXECUTABLE}\" fetch origin -q\n"
     "  RESULT_VARIABLE nok ERROR_VARIABLE error\n"
     "  WORKING_DIRECTORY \"${DIR}\")\n"
@@ -182,30 +194,42 @@ function(GIT_EXTERNAL DIR REPO TAG)
     "  message(FATAL_ERROR \"Fetch for ${__dir} failed:\n   \${error}\")\n"
     "endif()\n"
     "\n"
-    # update tag
-    "execute_process(COMMAND \"${GIT_EXECUTABLE}\" rebase FETCH_HEAD\n"
-    "  RESULT_VARIABLE nok ERROR_VARIABLE error OUTPUT_VARIABLE output\n"
-    "  WORKING_DIRECTORY \"${DIR}\")\n"
-    "if(nok)\n"
-    "  execute_process(COMMAND \"${GIT_EXECUTABLE}\" rebase --abort\n"
-    "    WORKING_DIRECTORY \"${DIR}\" ERROR_QUIET OUTPUT_QUIET)\n"
-    "  message(FATAL_ERROR \"Rebase ${__dir} failed:\n\${output}\${error}\")\n"
-    "endif()\n"
-    "\n"
-    # checkout requested tag
-    "execute_process(\n"
-    "  COMMAND \"${GIT_EXECUTABLE}\" checkout -q \"${TAG}\"\n"
-    "  RESULT_VARIABLE nok ERROR_VARIABLE error\n"
-    "  WORKING_DIRECTORY \"${DIR}\")\n"
-    "if(nok)\n"
-    "  message(FATAL_ERROR \"git checkout ${TAG} in ${__dir} failed: ${error}\n\")\n"
-    "endif()\n"
+  )
+  if("${TAG}" MATCHES "^[0-9a-f]+$")
+    # requested TAG is a SHA1, just switch to it
+    file(APPEND ${__rebase_cmake}
+      # checkout requested tag
+      "execute_process(\n"
+      "  COMMAND \"${GIT_EXECUTABLE}\" checkout -q \"${TAG}\"\n"
+      "  RESULT_VARIABLE nok ERROR_VARIABLE error\n"
+      "  WORKING_DIRECTORY \"${DIR}\")\n"
+      "if(nok)\n"
+      "  message(FATAL_ERROR \"git checkout ${TAG} in ${__dir} failed: ${error}\n\")\n"
+      "endif()\n"
     )
+  else()
+    # requested TAG is a branch
+    file(APPEND ${__rebase_cmake}
+      # switch to requested branch
+      "execute_process(\n"
+      "  COMMAND \"${GIT_EXECUTABLE}\" checkout -q \"${TAG}\"\n"
+      "  OUTPUT_QUIET ERROR_QUIET WORKING_DIRECTORY \"${DIR}\")\n"
+      # try to rebase it
+      "execute_process(COMMAND \"${GIT_EXECUTABLE}\" rebase FETCH_HEAD\n"
+      "  RESULT_VARIABLE nok ERROR_VARIABLE error OUTPUT_VARIABLE output\n"
+      "  WORKING_DIRECTORY \"${DIR}\")\n"
+      "if(nok)\n"
+      "  execute_process(COMMAND \"${GIT_EXECUTABLE}\" rebase --abort\n"
+      "    WORKING_DIRECTORY \"${DIR}\" ERROR_QUIET OUTPUT_QUIET)\n"
+      "  message(FATAL_ERROR \"Rebase ${__dir} failed:\n\${output}\${error}\")\n"
+      "endif()\n"
+    )
+  endif()
 
   if(NOT GIT_EXTERNAL_SCRIPT_MODE)
     add_custom_target(${__target}-rebase
       COMMAND ${CMAKE_COMMAND} -P ${__rebase_cmake}
-      COMMENT "Rebasing ${__dir}")
+      COMMENT "Rebasing ${__dir} [${TAG}]")
     set_target_properties(${__target}-rebase PROPERTIES
       EXCLUDE_FROM_DEFAULT_BUILD ON FOLDER git)
     if(NOT TARGET rebase)

--- a/lunchbox/compiler.h
+++ b/lunchbox/compiler.h
@@ -134,20 +134,22 @@
 #  define LB_LIKELY(x)       x
 #  define LB_UNLIKELY(x)     x
 #endif
-#ifdef LB_DEPRECATED
-#  define LB_PUSH_DEPRECATED                                          \
-    _Pragma("clang diagnostic push")                                  \
-    _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"") \
-    _Pragma("GCC diagnostic push")                                    \
+#ifndef LB_PUSH_DEPRECATED
+#  ifdef LB_DEPRECATED
+#    define LB_PUSH_DEPRECATED                                          \
+    _Pragma("clang diagnostic push")                                    \
+    _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")   \
+    _Pragma("GCC diagnostic push")                                      \
     _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
 
-#  define LB_POP_DEPRECATED                                         \
-    _Pragma("clang diagnostic pop")                                 \
+#    define LB_POP_DEPRECATED                                         \
+    _Pragma("clang diagnostic pop")                                   \
     _Pragma("GCC diagnostic pop")
-#else
-#  define LB_DEPRECATED
-#  define LB_PUSH_DEPRECATED
-#  define LB_POP_DEPRECATED
+#  else
+#    define LB_DEPRECATED
+#    define LB_PUSH_DEPRECATED
+#    define LB_POP_DEPRECATED
+#  endif
 #endif
 
 #endif //LUNCHBOX_COMPILER_H

--- a/lunchbox/debug.cpp
+++ b/lunchbox/debug.cpp
@@ -1,6 +1,6 @@
 
-/* Copyright (c) 2007-2014, Stefan Eilemann <eile@equalizergraphics.com>
- *               2009-2012, Daniel Nachbaur <danielnachbaur@gmail.com>
+/* Copyright (c) 2007-2015, Stefan Eilemann <eile@equalizergraphics.com>
+ *                          Daniel Nachbaur <danielnachbaur@gmail.com>
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License version 2.1 as published
@@ -20,6 +20,8 @@
 
 #include "os.h" // must come before atomic.h, ordering issue
 #include "atomic.h"
+#include "sleep.h"
+#include "thread.h"
 
 #include <errno.h>
 
@@ -39,9 +41,17 @@
 namespace lunchbox
 {
 
-void abort()
+void abort( const bool dumpThreads )
 {
-    LBERROR << "  in: " << backtrace << std::endl;
+    LBERROR << "  in: " << backtrace << "\n";
+    if( dumpThreads )
+    {
+        LBERROR << "\nThreads:" << std::endl;
+        Thread::_dumpAll();
+        sleep( 100 ); // threads need a bit to print
+    }
+    else
+        LBERROR << std::endl;
 
     // if LB_ABORT_WAIT is set, spin forever to allow identifying and debugging
     // crashed nodes.
@@ -154,7 +164,7 @@ static void backtrace_( std::ostream& os, const size_t skipFrames )
                 os << name;
         }
     }
-    os << std::endl;
+    os << "\n";
     ::free( names );
 #endif
 }

--- a/lunchbox/debug.h
+++ b/lunchbox/debug.h
@@ -33,7 +33,7 @@ namespace lunchbox
  * @internal
  * Used to trap into an infinite loop to allow debugging of assertions
  */
-LUNCHBOX_API void abort();
+LUNCHBOX_API void abort( bool dumpThreads = false );
 
 /**
  * @internal

--- a/lunchbox/thread.h
+++ b/lunchbox/thread.h
@@ -175,7 +175,10 @@ private:
 
     static void* runChild( void* arg );
     void        _runChild();
-};// LB_DEPRECATED;
+
+    friend void lunchbox::abort( bool );
+    static void _dumpAll();
+};
 
 /** Output the affinity setting in human-readable form. @version 1.7.1 */
 LUNCHBOX_API std::ostream& operator << ( std::ostream&, const Thread::Affinity );

--- a/lunchbox/threadID.cpp
+++ b/lunchbox/threadID.cpp
@@ -59,6 +59,15 @@ bool ThreadID::operator != ( const ThreadID& rhs ) const
     return !pthread_equal( _impl->pthread, rhs._impl->pthread );
 }
 
+bool ThreadID::operator < ( const ThreadID& rhs ) const
+{
+#ifdef PTW32_VERSION
+    return _impl->pthread.p < rhs._impl->pthread.p;
+#else
+    return _impl->pthread < rhs._impl->pthread;
+#endif
+}
+
 std::ostream& operator << ( std::ostream& os, const ThreadID& threadID )
 {
 #ifdef PTW32_VERSION

--- a/lunchbox/threadID.h
+++ b/lunchbox/threadID.h
@@ -1,6 +1,6 @@
 
-/* Copyright (c) 2010-2013, Stefan Eilemann <eile@eyescale.ch>
- *                    2012, Daniel Nachbaur <danielnachbaur@gmail.com>
+/* Copyright (c) 2010-2015, Stefan Eilemann <eile@eyescale.ch>
+ *                          Daniel Nachbaur <danielnachbaur@gmail.com>
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License version 2.1 as published
@@ -28,10 +28,7 @@ namespace lunchbox
 {
 namespace detail { class ThreadID; }
 
-/**
- * An utility class to wrap OS-specific thread identifiers.
- * @deprecated Use Boost.Thread
- */
+/** An utility class to wrap OS-specific thread identifiers. */
 class ThreadID
 {
 public:
@@ -56,13 +53,16 @@ public:
      */
     LUNCHBOX_API bool operator != ( const ThreadID& rhs ) const;
 
+    /** @internal */
+    bool operator < ( const ThreadID& rhs ) const;
+
 private:
     detail::ThreadID* const _impl;
     friend class Thread;
 
     friend LUNCHBOX_API
     std::ostream& operator << ( std::ostream& os, const ThreadID& );
-};// LB_DEPRECATED;
+};
 
 /** Print the thread to the given output stream. */
 LUNCHBOX_API std::ostream& operator << ( std::ostream&, const ThreadID& );


### PR DESCRIPTION
Use case is to get a bit more info on the deadlock tests on Jenkins. Sample output:
```
18542.Main            ../tests/perf/lock.cpp:83       13 Assert: false
in:
  5: lunchbox::abort()
  4: void _test<lunchbox::SpinLock>()
  3: testMain(int, char**)
  2: tests/perf-lock(main+0x7e) [0x40316e]
  1: __libc_start_main
  0: tests/perf-lock() [0x402db9]


Threads:
18542.4               ../lunchbox/thread.cpp:77       14 :
  10:
  /home/eilemann/config.bbp/Lunchbox/build/lib/libLunchbox.so.5(+0x49738)
  [0x7f6edd589738]
  9: /lib/x86_64-linux-gnu/libc.so.6(+0x36d40) [0x7f6edcc97d40]
  8: __sched_yield
  7: lunchbox::Thread::yield()
  6: lunchbox::detail::SpinLock::set()
  5: lunchbox::SpinLock::set()
  4: Thread<lunchbox::SpinLock>::run()
  3: lunchbox::Thread::_runChild()
  2: lunchbox::Thread::runChild(void*)
  1: /lib/x86_64-linux-gnu/libpthread.so.0(+0x8182) [0x7f6edc0eb182]
  0: /lib/x86_64-linux-gnu/libc.so.6(clone+0x6d) [0x7f6edcd5b47d]

18542.5               ../lunchbox/thread.cpp:77       14 :
  10:
  /home/eilemann/config.bbp/Lunchbox/build/lib/libLunchbox.so.5(+0x49738)
  [0x7f6edd589738]
  9: /lib/x86_64-linux-gnu/libc.so.6(+0x36d40) [0x7f6edcc97d40]
  8: __sched_yield
  7: lunchbox::Thread::yield()
  6: lunchbox::detail::SpinLock::set()
  5: lunchbox::SpinLock::set()
  4: Thread<lunchbox::SpinLock>::run()
  3: lunchbox::Thread::_runChild()
  2: lunchbox::Thread::runChild(void*)
  1: /lib/x86_64-linux-gnu/libpthread.so.0(+0x8182) [0x7f6edc0eb182]
  0: /lib/x86_64-linux-gnu/libc.so.6(clone+0x6d) [0x7f6edcd5b47d]

18542.2               ../lunchbox/thread.cpp:77       14 :
  10:
  /home/eilemann/config.bbp/Lunchbox/build/lib/libLunchbox.so.5(+0x49738)
  [0x7f6edd589738]
  9: /lib/x86_64-linux-gnu/libc.so.6(+0x36d40) [0x7f6edcc97d40]
  8: __sched_yield
  7: lunchbox::Thread::yield()
  6: lunchbox::detail::SpinLock::set()
  5: lunchbox::SpinLock::set()
  4: Thread<lunchbox::SpinLock>::run()
  3: lunchbox::Thread::_runChild()
  2: lunchbox::Thread::runChild(void*)
  1: /lib/x86_64-linux-gnu/libpthread.so.0(+0x8182) [0x7f6edc0eb182]
  0: /lib/x86_64-linux-gnu/libc.so.6(clone+0x6d) [0x7f6edcd5b47d]

18542.Watchdog        ../lunchbox/thread.cpp:77       14 :
  8:
  /home/eilemann/config.bbp/Lunchbox/build/lib/libLunchbox.so.5(+0x49738)
  [0x7f6edd589738]
  7: /lib/x86_64-linux-gnu/libc.so.6(+0x36d40) [0x7f6edcc97d40]
  6: /lib/x86_64-linux-gnu/libc.so.6(nanosleep+0x2d) [0x7f6edcd21f3d]
  5: lunchbox::sleep(unsigned int)
  4: tests/perf-lock() [0x402f42]
  3: lunchbox::Thread::_runChild()
  2: lunchbox::Thread::runChild(void*)
  1: /lib/x86_64-linux-gnu/libpthread.so.0(+0x8182) [0x7f6edc0eb182]
  0: /lib/x86_64-linux-gnu/libc.so.6(clone+0x6d) [0x7f6edcd5b47d]

18542.3               ../lunchbox/thread.cpp:77       14 :
  10:
  /home/eilemann/config.bbp/Lunchbox/build/lib/libLunchbox.so.5(+0x49738)
  [0x7f6edd589738]
  9: /lib/x86_64-linux-gnu/libc.so.6(+0x36d40) [0x7f6edcc97d40]
  8: __sched_yield
  7: lunchbox::Thread::yield()
  6: lunchbox::detail::SpinLock::set()
  5: lunchbox::SpinLock::set()
  4: Thread<lunchbox::SpinLock>::run()
  3: lunchbox::Thread::_runChild()
  2: lunchbox::Thread::runChild(void*)
  1: /lib/x86_64-linux-gnu/libpthread.so.0(+0x8182) [0x7f6edc0eb182]
  0: /lib/x86_64-linux-gnu/libc.so.6(clone+0x6d) [0x7f6edcd5b47d]

Abort (core dumped)
```