### PR TITLE
Tweak clock tests for machines with very coarse timer resolution.

### DIFF
--- a/tests/clock.cpp
+++ b/tests/clock.cpp
@@ -32,7 +32,7 @@ int main( int, char** )
     TEST( clock.resetTimef() > 0.f );
     lunchbox::sleep( 100.f );
     TEST( clock.getTimef() >  99.f );
-    TEST( clock.getTimef() < 110.f );
+    TEST( clock.getTimef() < 115.f );
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
For example the VMs running CI at the moment.