### PR TITLE
Make Buffer copy and move ctors non-explicit.

### DIFF
--- a/lunchbox/buffer.h
+++ b/lunchbox/buffer.h
@@ -51,10 +51,10 @@ public:
         { reset( size ); }
 
     /** Copy constructor, copies data to new Buffer. @version 1.14 */
-    explicit Buffer( const Buffer& from );
+    Buffer( const Buffer& from );
 
     /** Move constructor, transfers data to new Buffer. @version 1.14 */
-    explicit Buffer( Buffer&& from );
+    Buffer( Buffer&& from );
 
     /** Destruct the buffer. @version 1.0 */
     ~Buffer() { clear(); }


### PR DESCRIPTION
From http://stackoverflow.com/questions/6758717:

  Put more simply, an explicit move or copy constructor defies
  expectations and can't be used as well with generic code.