### PR TITLE
Add missing header for C++11 unique_ptr support

### DIFF
--- a/lunchbox/spinLock.h
+++ b/lunchbox/spinLock.h
@@ -18,11 +18,10 @@
 #ifndef LUNCHBOX_SPINLOCK_H
 #define LUNCHBOX_SPINLOCK_H
 
-#include <memory>
-
-
 #include <lunchbox/atomic.h> // member
 #include <lunchbox/thread.h> // used in inline method
+
+#include <memory>
 
 namespace lunchbox
 {

--- a/lunchbox/spinLock.h
+++ b/lunchbox/spinLock.h
@@ -18,6 +18,7 @@
 #ifndef LUNCHBOX_SPINLOCK_H
 #define LUNCHBOX_SPINLOCK_H
 
+#include <memory>
 #include <lunchbox/atomic.h> // member
 #include <lunchbox/thread.h> // used in inline method
 

--- a/lunchbox/spinLock.h
+++ b/lunchbox/spinLock.h
@@ -19,6 +19,8 @@
 #define LUNCHBOX_SPINLOCK_H
 
 #include <memory>
+
+
 #include <lunchbox/atomic.h> // member
 #include <lunchbox/thread.h> // used in inline method
 


### PR DESCRIPTION
The Spinlock uses a Pimpl pattern with unique_ptr but forget to include memory, causing the compilation of spinlock.cpp to fail under some compiler versions