### PR TITLE
Some Windows-related fixes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,10 @@ endif()
 
 add_definitions("-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}")
 
+if(MSVC)
+  add_definitions("-DHAVE_STRUCT_TIMESPEC")
+endif()
+
 include(pthreads/CMakeLists.txt)
 
 add_subdirectory(lunchbox)

--- a/lunchbox/debug.cpp
+++ b/lunchbox/debug.cpp
@@ -23,6 +23,7 @@
 #include "sleep.h"
 #include "thread.h"
 
+#include <mutex>
 #include <errno.h>
 
 #define LB_BACKTRACE_DEPTH 256
@@ -83,8 +84,8 @@ static void backtrace_(std::ostream& os, const size_t skipFrames)
 {
 #ifdef _WIN32
     // Sym* functions from DbgHelp are not thread-safe...
-    static Lock lock;
-    ScopedMutex<> mutex(lock);
+    static std::mutex lock;
+    ScopedWrite scopedWrite(lock);
 
     typedef USHORT(WINAPI * CaptureStackBackTraceType)(ULONG, ULONG, PVOID*,
                                                        PULONG);

--- a/lunchbox/lfVector.ipp
+++ b/lunchbox/lfVector.ipp
@@ -99,7 +99,7 @@ LFVector<T, nSlots>& LFVector<T, nSlots>::operator=(
     {
         if (from.slots_[i])
         {
-            const size_t sz = 1 << i;
+            const size_t sz = size_t(1) << i;
             if (!slots_[i])
                 slots_[i] = new T[sz];
 

--- a/lunchbox/memoryMap.cpp
+++ b/lunchbox/memoryMap.cpp
@@ -104,7 +104,7 @@ private:
         {
             LBWARN << "Can't open " << filename << ": " << sysError
                    << std::endl;
-            return;
+            return NULL;
         }
         return _mapFile(size_);
     }

--- a/lunchbox/os.h
+++ b/lunchbox/os.h
@@ -45,7 +45,6 @@
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
-#include <windef.h>
 #include <windows.h>
 #include <winsock2.h>
 #endif

--- a/lunchbox/plugin.h
+++ b/lunchbox/plugin.h
@@ -74,13 +74,23 @@ public:
 
     /** @return the plugin's description. @version 1.17 */
     std::string getDescription() const { return _description(); }
+	
+	bool operator==(const Plugin& rhs) const	// TEST
+	{
+		return &_constructor == &rhs._constructor	&&
+			   &_handles == &rhs._handles			&&
+			   _description() == rhs._description();
+	}
+
+	bool operator!=(const Plugin& rhs) const	// TEST
+	{
+		return !(*this == rhs);
+	}
+
 private:
     Constructor _constructor;
     HandlesFunc _handles;
     DescriptionFunc _description;
-
-    bool operator==(const Plugin& rhs) const = delete;
-    bool operator!=(const Plugin& rhs) const = delete;
 };
 }
 

--- a/lunchbox/rng.cpp
+++ b/lunchbox/rng.cpp
@@ -25,8 +25,8 @@
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
-#include <wincrypt.h>
 #include <wtypes.h>
+#include <wincrypt.h>
 #pragma comment(lib, "advapi32.lib")
 #else
 #include <unistd.h>


### PR DESCRIPTION
Beware of the comparison operators in lunchbox/plugin.h .
The problem which still needs to be solved properly is the following:
How can we find a plugin in pluginFactory.ipp, line 71 as follows

std::find(_plugins.begin(), _plugins.end(), plugin);

If there is no comparison operator for Plugin?
At least MSVC complaints about this.

Also: depending on your MSVC version, you run into trouble when pthreads-w32 defines struct timespec, as it already is defined in the Windows SDK. To prevent this, we can define HAVE_STRUCT_TIMESPEC.